### PR TITLE
Bump dask version

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -11,7 +11,7 @@ RAPIDS_PY_CUDA_SUFFIX=$(echo "cu${RAPIDS_CUDA_VERSION:-12.15.1}" | cut -d '.' -f
 
 # TODO: set this to main once dask-cudf is compatible
 # DASK_VERSION=main
-DASK_VERSION=2024.12.1
+DASK_VERSION=main
 export PIP_YES=true
 export PIP_PRE=true
 
@@ -33,7 +33,7 @@ if [ ! -d "distributed" ]; then
 fi
 
 pip uninstall dask distributed
-cd dask && git clean -fdx && git checkout $DASK_VERSION && pip install -e .[test] && cd ..
-cd distributed && git clean -fdx && git checkout $DASK_VERSION && pip install -e . && cd ..
+cd dask &&  pip install -e .[test] && cd ..
+cd distributed && pip install -e . && cd ..
 
 ./scripts/test.sh

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -25,11 +25,11 @@ pip install --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/
 echo "Installing dask@{DASK_VERSION}"
 
 if [ ! -d "dask" ]; then
-    git clone https://github.com/dask/dask
+    git clone https://github.com/dask/dask --depth 1 --branch $DASK_VERSION
 fi
 
 if [ ! -d "distributed" ]; then
-    git clone https://github.com/dask/distributed
+    git clone https://github.com/dask/distributed --depth 1 --branch $DASK_VERSION
 fi
 
 pip uninstall dask distributed


### PR DESCRIPTION
This bumps the verison of dask / distributed we run against to `main`.

It also speeds up the test runs a bit by only cloning a single commit.
 
With this, a single test is failing for me on a dgx: `distributed/comm/tests/test_ucx.py::test_stress`, which I'm looking into (edit: https://github.com/dask/distributed/pull/9002).