### PR TITLE
Fix dask / distributed installation

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -24,16 +24,22 @@ pip install --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/
 
 echo "Installing dask@{DASK_VERSION}"
 
+# depth needs to be sufficient to reach the last tag, so that the package
+# versions are set correctly
 if [ ! -d "dask" ]; then
-    git clone https://github.com/dask/dask --depth 1 --branch $DASK_VERSION
+    git clone https://github.com/dask/dask --depth 100 --branch $DASK_VERSION
 fi
 
 if [ ! -d "distributed" ]; then
-    git clone https://github.com/dask/distributed --depth 1 --branch $DASK_VERSION
+    git clone https://github.com/dask/distributed --depth 100 --branch $DASK_VERSION
 fi
 
+# Install everything, including any new dependencies
 pip uninstall dask distributed
-cd dask &&  pip install -e .[test] && cd ..
-cd distributed && pip install -e . && cd ..
+pip install -e ./dask[test]
+pip install -e ./distributed
+
+echo "[Setup done]"
+pip list
 
 ./scripts/test.sh

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 # SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES.
 
+echo "[testing dask]"
 pushd dask
 pytest dask -v -m gpu
 dask_status=$?
 popd
 
+echo "[testing distributed]"
 pushd distributed
 pytest distributed -v -m gpu --runslow
 distributed_status=$?


### PR DESCRIPTION
The previous run failed to run the Dask tests

https://github.com/rapidsai/dask-upstream-testing/actions/runs/13164022831/job/36739676950#step:9:392

```
ImportError while loading conftest '/__w/dask-upstream-testing/dask-upstream-testing/dask/dask/conftest.py'.
_pytest.pathlib.ImportPathMismatchError: ('dask.conftest', '/pyenv/versions/3.10.16/lib/python3.10/site-packages/dask/conftest.py', PosixPath('/__w/dask-upstream-testing/dask-upstream-testing/dask/dask/conftest.py'))
```

It looks like the local dask was uninstalled when we intalled distributed. Most likely, this was because the `--depth=1` we cloned the repository with broke dask's local version system (using git tags). This PR clones with a larger depth and adds a bit of debug output.