### PR TITLE
Add cuml, raft-dask

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -3,8 +3,9 @@ name: Test dask-upstream
 
 on:
   schedule:
+    # 06:15 UTC daily.
     # 18:15 UTC daily.
-    # We want to run after the nightly pipeline finishes.
+    # We at least one one run after the nightly pipeline finishes.
     # https://github.com/rapidsai/workflows/blob/main/.github/workflows/nightly-pipeline-trigger.yaml is
     # currently set to 5:00 UTC and takes ~12 hours
     - cron: "15 18 * * *"

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -3,12 +3,11 @@ name: Test dask-upstream
 
 on:
   schedule:
-    # 06:15 UTC daily.
-    # 18:15 UTC daily.
-    # We at least one one run after the nightly pipeline finishes.
+    # 06:15 and 08:15 UTC daily.
+    # We want at least one one run after the nightly pipeline finishes.
     # https://github.com/rapidsai/workflows/blob/main/.github/workflows/nightly-pipeline-trigger.yaml is
     # currently set to 5:00 UTC and takes ~12 hours
-    - cron: "15 18 * * *"
+    - cron: "15 06,18 * * *"
   workflow_dispatch: {}
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dask
 distributed
 cudf
 dask-cuda
+packages

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,13 +25,12 @@ repos:
             .*test.*|
             ^CHANGELOG.md$
           )
-  # Include this if we add any Python code
-  # - repo: https://github.com/astral-sh/ruff-pre-commit
-  #   rev: v0.9.3
-  #   hooks:
-  #     - id: ruff
-  #       args: ["--fix"]
-  #     - id: ruff-format
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.3
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+      - id: ruff-format
   - repo: https://github.com/rapidsai/pre-commit-hooks
     rev: v0.6.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![Test dask-upstream](https://github.com/rapidsai/dask-upstream-testing/actions/workflows/cron.yaml/badge.svg)](https://github.com/rapidsai/dask-upstream-testing/actions/workflows/cron.yaml)
 
-This repository contains the scripts to run Dask's `gpu`-marked tests on a schedule.
+This repository contains the scripts to run Dask's `gpu`-marked tests on a schedule
+and dask-dependent tests from some downstream libraries.
 
 ## Version Policy
 

--- a/requirements/overrides.txt
+++ b/requirements/overrides.txt
@@ -1,0 +1,2 @@
+dask @ git+https://github.com/dask/dask.git@main
+distributed @ git+https://github.com/dask/distributed.git@main

--- a/scripts/check-version.py
+++ b/scripts/check-version.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES.
+"""
+Print the git commit a rapids package was built from.
+"""
+
+import argparse
+import importlib
+import sys
+import importlib.resources
+
+
+def parse_args(args=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("distribution", help="Package name to check.")
+
+    return parser.parse_args(args)
+
+
+def main(args=None):
+    args = parse_args(args)
+    dist = args.distribution
+
+    try:
+        sha = importlib.resources.files(dist).joinpath("GIT_COMMIT").read_text().strip()
+    except ModuleNotFoundError:
+        print(f"Error: {dist} is not installed.", file=sys.stderr)
+    except FileNotFoundError:
+        print(f"Error: {dist} does not contain 'GIT_COMMIT' file.", file=sys.stderr)
+    else:
+        print(sha)
+        sys.exit(0)
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -66,5 +66,8 @@ pushd distributed
 git checkout $DASK_VERSION
 popd
 
+# Finally, ensure that
+uv pip install --no-deps -e ./dask ./distributed
+
 echo "[Setup done]"
 uv pip list

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,8 +6,6 @@ set -euo pipefail
 # We want cu12
 RAPIDS_PY_CUDA_SUFFIX=$(echo "cu${RAPIDS_CUDA_VERSION:-12.15.1}" | cut -d '.' -f 1)
 
-DASK_VERSION=main
-
 uv pip install --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple \
   --overrides=requirements/overrides.txt \
   --prerelease allow \
@@ -79,21 +77,21 @@ popd
 # depth needs to be sufficient to reach the last tag, so that the package
 # versions are set correctly
 if [ ! -d "dask" ]; then
-    echo "Cloning dask@{$DASK_VERSION}"
-    git clone https://github.com/dask/dask --depth 100 --branch $DASK_VERSION packages
+    echo "Cloning dask@main"
+    git clone https://github.com/dask/dask --depth 100 packages
 fi
 
 if [ ! -d "distributed" ]; then
-    echo "Cloning dask@{$DASK_VERSION}"
-    git clone https://github.com/dask/distributed --depth 100 --branch $DASK_VERSION packages
+    echo "Cloning distributed@main"
+    git clone https://github.com/dask/distributed --depth 100 packages
 fi
 
 pushd packages/dask
-git checkout $DASK_VERSION
+git checkout main
 popd
 
 pushd packages/distributed
-git checkout $DASK_VERSION
+git checkout main
 popd
 
 # Finally, ensure that

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,11 +6,7 @@ set -euo pipefail
 # We want cu12
 RAPIDS_PY_CUDA_SUFFIX=$(echo "cu${RAPIDS_CUDA_VERSION:-12.15.1}" | cut -d '.' -f 1)
 
-# TODO: set this to main once dask-cudf is compatible
-# DASK_VERSION=main
 DASK_VERSION=main
-export PIP_YES=true
-export PIP_PRE=true
 
 # Try
 uv pip install --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple \

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+set -euo pipefail
+
+# RAPIDS_CUDA_VERSION is like 12.15.1
+# We want cu12
+RAPIDS_PY_CUDA_SUFFIX=$(echo "cu${RAPIDS_CUDA_VERSION:-12.15.1}" | cut -d '.' -f 1)
+
+# TODO: set this to main once dask-cudf is compatible
+# DASK_VERSION=main
+DASK_VERSION=main
+export PIP_YES=true
+export PIP_PRE=true
+
+# Try
+uv pip install --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple \
+  --overrides=requirements/overrides.txt \
+  --prerelease allow \
+  "cudf-${RAPIDS_PY_CUDA_SUFFIX}" \
+  "dask-cudf-${RAPIDS_PY_CUDA_SUFFIX}" \
+  "ucx-py-${RAPIDS_PY_CUDA_SUFFIX}" \
+  "ucxx-${RAPIDS_PY_CUDA_SUFFIX}" \
+  "scipy" \
+  "dask-cuda"
+
+# Clone cudf repo for tests
+CUDF_VERSION="branch-25.04"
+cudf_commit=$(./scripts/check-version.py cudf)
+
+if [ ! -d "cudf" ]; then
+    echo "Cloning cudf@{$CUDF_VERSION}"
+    git clone https://github.com/rapidsai/cudf.git --branch $CUDF_VERSION
+fi
+
+pushd cudf
+git checkout $cudf_commit
+popd
+
+if [ ! -d "dask-cuda" ]; then
+    echo "Cloning cudf@{$CUDF_VERSION}"
+    git clone https://github.com/rapidsaicudf_commit/dask-cuda.git --branch $CUDF_VERSION
+fi
+
+# Clone dask-cuda for tests
+# dask-cuda nightly wheels currently lack a __git_commit__.
+# Looking into it, but for now just use the branch.
+
+# dask_cuda_commit=$(./scripts/check-version.py dask_cuda)
+
+pushd dask-cuda
+git checkout $CUDF_VERSION
+popd
+
+# depth needs to be sufficient to reach the last tag, so that the package
+# versions are set correctly
+if [ ! -d "dask" ]; then
+    echo "Cloning dask@{$DASK_VERSION}"
+    git clone https://github.com/dask/dask --depth 100 --branch $DASK_VERSION
+fi
+
+if [ ! -d "distributed" ]; then
+    echo "Cloning dask@{$DASK_VERSION}"
+    git clone https://github.com/dask/distributed --depth 100 --branch $DASK_VERSION
+fi
+
+pushd dask
+git checkout $DASK_VERSION
+popd
+
+pushd distributed
+git checkout $DASK_VERSION
+popd
+
+echo "[Setup done]"
+uv pip list

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,7 +8,6 @@ RAPIDS_PY_CUDA_SUFFIX=$(echo "cu${RAPIDS_CUDA_VERSION:-12.15.1}" | cut -d '.' -f
 
 DASK_VERSION=main
 
-# Try
 uv pip install --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple \
   --overrides=requirements/overrides.txt \
   --prerelease allow \

--- a/scripts/overrides.txt
+++ b/scripts/overrides.txt
@@ -1,0 +1,4 @@
+# used to force installing dask / distributed main
+# even if another package like rapids-dask-dependency wants something else
+dask[test] @ git+https://github.com/dask/dask.git@main
+distributed @ git+https://github.com/dask/distributed.git@main

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
 
+# Install
 set -euo pipefail
 
-./scripts/setup.sh
-./scripts/install.sh
-./scripts/test.sh
+if ! command -v uv > /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -56,7 +56,7 @@ exit_code=0;
 if $run_cuml; then
 
     echo "[testing cuml]"
-    pytest -v packages/cuml/python/cuml/cuml/tests/dask
+    pytest -v --quick_run packages/cuml/python/cuml/cuml/tests/dask
 
     if [[ $? -ne 0 ]]; then
         exit_code=1

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -76,8 +76,8 @@ fi
 if $run_dask; then
 
     echo "[testing dask]"
-    pushd dask || exit 1
-    pytest -v -m gpu dask
+    pushd dask/dask || exit 1
+    pytest -v -m gpu .
 
     if [[ $? -ne 0 ]]; then
         exit_code=1
@@ -87,7 +87,7 @@ if $run_dask; then
 
 fi
 
-# --- dask ---
+# --- distributed ---
 
 if $run_distributed; then
 


### PR DESCRIPTION
- added setup.sh, which installs uv if it isn't present
- moved most of `run.sh` contents to install.sh
- ensures that we checkout the correct commit for tests (except dask_cuda, which doesn't have a `__git_commit__` set currently)

Closes https://github.com/rapidsai/dask-upstream-testing/issues/12