### PR TITLE
Source uv env

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -6,4 +6,5 @@ set -euo pipefail
 
 if ! command -v uv > /dev/null; then
     curl -LsSf https://astral.sh/uv/install.sh | sh
+    source $HOME/.local/bin/env
 fi


### PR DESCRIPTION
Failure at https://github.com/rapidsai/dask-upstream-testing/actions/runs/13442077613/job/37558756781


```
./scripts/install.sh: line 9: uv: command not found
```

Updates the setup to source `uv`