### PR TITLE
Source env in the right script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,6 +2,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
 set -euo pipefail
 
+if ! command -v uv > /dev/null; then
+    source $HOME/.local/bin/env
+fi
+
 # RAPIDS_CUDA_VERSION is like 12.15.1
 # We want cu12
 RAPIDS_PY_CUDA_SUFFIX=$(echo "cu${RAPIDS_CUDA_VERSION:-12.15.1}" | cut -d '.' -f 1)

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -6,5 +6,4 @@ set -euo pipefail
 
 if ! command -v uv > /dev/null; then
     curl -LsSf https://astral.sh/uv/install.sh | sh
-    source $HOME/.local/bin/env
 fi


### PR DESCRIPTION
Second attempt at fixing https://github.com/rapidsai/dask-upstream-testing/pull/14

That failed previously, because we sourced the uv env in the childe `setup.sh` script, which can't modify the PATH of the paraent `./run.sh` script.

So we do it in `install.sh`, which is the only place using `uv`.