### PR TITLE
Install in venv

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,6 +6,9 @@ if ! command -v uv > /dev/null; then
     source $HOME/.local/bin/env
 fi
 
+uv venv --allow-existing
+source .venv/bin/activate
+
 # RAPIDS_CUDA_VERSION is like 12.15.1
 # We want cu12
 RAPIDS_PY_CUDA_SUFFIX=$(echo "cu${RAPIDS_CUDA_VERSION:-12.15.1}" | cut -d '.' -f 1)


### PR DESCRIPTION
`uv` won't install in the global environment by default, which caused a failure at https://github.com/rapidsai/dask-upstream-testing/actions/runs/13442782421/job/37561013246.

This ensures we create / use a venv in `./scripts/install`