### PR TITLE
Fix dask-cuda clone

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -41,7 +41,6 @@ if [ ! -d "packages/cudf" ]; then
 fi
 
 pushd packages/cudf
-git fetch
 git checkout $cudf_commit
 popd
 
@@ -71,7 +70,7 @@ popd
 
 if [ ! -d "packages/dask-cuda" ]; then
     echo "Cloning cudf@{$CUDF_VERSION}"
-    git clone https://github.com/rapidsaicudf_commit/dask-cuda.git --branch $CUDF_VERSION packages/dask-cuda
+    git clone https://github.com/rapidsai/dask-cuda.git --branch $CUDF_VERSION packages/dask-cuda
 fi
 
 # Clone dask-cuda for tests


### PR DESCRIPTION
There was a typo in the dask-cuda clone command, which caused the failure at https://github.com/rapidsai/dask-upstream-testing/actions/runs/13443646257/job/37563861816.