### PR TITLE
Source uv in run.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,13 +2,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
 set -euo pipefail
 
-if ! command -v uv > /dev/null; then
-    source $HOME/.local/bin/env
-fi
-
-uv venv --allow-existing
-source .venv/bin/activate
-
 # RAPIDS_CUDA_VERSION is like 12.15.1
 # We want cu12
 RAPIDS_PY_CUDA_SUFFIX=$(echo "cu${RAPIDS_CUDA_VERSION:-12.15.1}" | cut -d '.' -f 1)

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -4,5 +4,13 @@
 set -euo pipefail
 
 ./scripts/setup.sh
+
+if ! command -v uv > /dev/null; then
+    source $HOME/.local/bin/env
+fi
+
+uv venv --allow-existing
+source .venv/bin/activate
+
 ./scripts/install.sh
 ./scripts/test.sh

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -56,7 +56,7 @@ exit_code=0;
 if $run_cuml; then
 
     echo "[testing cuml]"
-    pytest -v --quick_run packages/cuml/python/cuml/cuml/tests/dask
+    pytest -v --quick_run --import-mode importlib packages/cuml/python/cuml/cuml/tests/dask
 
     if [[ $? -ne 0 ]]; then
         exit_code=1


### PR DESCRIPTION
Previous commits installed our packages into a virtualenv. That venv was activated in `install.sh`, but wasn't in `test.sh`.

This moves the venv management to the parent `run.sh`. Then it should be activate for both `install.sh` and `test.sh`.

The change to the `cuml` pytest call is from local testing reveling that it might be necessary? I'm pretty sure I had a successful run without the `--import-mode`, but now I was seeing errors about `E   AttributeError: module 'dask' has no attribute 'config'`, which indicates that we had a directory named `dask` on our import path that wasn't the actual dask package.

Fixes the failure at https://github.com/rapidsai/dask-upstream-testing/actions/runs/13444080870/job/37565269167