### PR TITLE
Fixed overrides

### DIFF
--- a/requirements/overrides.txt
+++ b/requirements/overrides.txt
@@ -1,2 +1,2 @@
-dask @ git+https://github.com/dask/dask.git@main
+dask[test] @ git+https://github.com/dask/dask.git@main
 distributed @ git+https://github.com/dask/distributed.git@main

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,8 +17,7 @@ uv pip install --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-night
   "ucxx-${RAPIDS_PY_CUDA_SUFFIX}" \
   "scipy" \
   "dask-cuda" \
-  "pytest-timeout" \
-  "dask[test]"
+  "pytest-timeout"
 
 # packages holds all the downstream and upstream dependencies.
 # we want to avoid directories with the same name as packages

--- a/scripts/overrides.txt
+++ b/scripts/overrides.txt
@@ -1,4 +1,0 @@
-# used to force installing dask / distributed main
-# even if another package like rapids-dask-dependency wants something else
-dask[test] @ git+https://github.com/dask/dask.git@main
-distributed @ git+https://github.com/dask/distributed.git@main


### PR DESCRIPTION
We had two issues with our overrides files:

1. We had a duplicate under scripts/ that wasn't used
2. The one being used missed a `[test]` extra, causing failues in the dask and distributed tests