### PR TITLE
Removed import-mode for cuml tests

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -56,7 +56,7 @@ exit_code=0;
 if $run_cuml; then
 
     echo "[testing cuml]"
-    pytest -v --timeout=120 --quick_run --import-mode importlib packages/cuml/python/cuml/cuml/tests/dask
+    pytest -v --timeout=120 --quick_run packages/cuml/python/cuml/cuml/tests/dask
 
     if [[ $? -ne 0 ]]; then
         exit_code=1


### PR DESCRIPTION
Previous versions of this test runner needed `--import-mode=importlib` to avoid the `cuml/tests/dask` directory from shadowing the `dask` module. Now that we don't `cd` into the test directory, it seems we're able to remove the `--import-mode` argument.

`--import-mode=importlib` was causing some other tests to fail with serialization issues (see https://github.com/rapidsai/dask-upstream-testing/actions/runs/13485720207/job/37676609090#step:10:2302). Top-level functions defined in the test file would be given a `__module__` of `cuml.tests`, which isn't a real module that's importable on workers (which aren't usings pytest's special import mechanism).

Closes https://github.com/rapidsai/dask-upstream-testing/issues/23