### PR TITLE
Added dask-image

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,6 +9,8 @@ RAPIDS_PY_CUDA_SUFFIX=$(echo "cu${RAPIDS_CUDA_VERSION:-12.15.1}" | cut -d '.' -f
 uv pip install --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple \
   --overrides=requirements/overrides.txt \
   --prerelease allow \
+  --upgrade \
+  "dask-image[test] @ git+https://github.com/dask/dask-image.git@main" \
   "cuml-${RAPIDS_PY_CUDA_SUFFIX}[test]" \
   "cudf-${RAPIDS_PY_CUDA_SUFFIX}" \
   "dask-cudf-${RAPIDS_PY_CUDA_SUFFIX}" \
@@ -88,6 +90,18 @@ fi
 pushd packages/dask-cuda
 git fetch
 git checkout $RAPIDS_BRANCH
+popd
+
+
+if [ ! -d "packages/dask-image" ]; then
+    echo "Cloning dask-image"
+    git clone https://github.com/dask/dask-image.git --depth 100 packages/dask-image
+fi
+
+pushd packages/dask-image
+git fetch
+git checkout main
+uv pip install -e . --no-deps
 popd
 
 # depth needs to be sufficient to reach the last tag, so that the package

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -105,7 +105,7 @@ fi
 if $run_dask_image; then
 
     echo "[testing dask-image]"
-    pytest -v packages/dask-image/
+    pytest -v packages/dask-image/ -m cupy
 
     if [[ $? -ne 0 ]]; then
         exit_code=1

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -6,6 +6,7 @@ if [ $# -eq 0 ]; then
     run_dask=true
     run_dask_cuda=true
     run_dask_cudf=true
+    run_dask_image=true
     run_distributed=true
     run_raft_dask=true
     run_ucxx=true
@@ -14,6 +15,7 @@ else
     run_dask=false
     run_dask_cuda=false
     run_dask_cudf=false
+    run_dask_image=false
     run_distributed=false
     run_raft_dask=false
     run_ucxx=false
@@ -34,6 +36,9 @@ while [[ $# -gt 0 ]]; do
         --dask-cudf-only)
             run_dask_cudf=true
             ;;
+        --dask-image-only)
+            run_dask_image=true
+            ;;
         --distributed-only)
             run_distributed=true
             ;;
@@ -44,7 +49,7 @@ while [[ $# -gt 0 ]]; do
             run_ucxx=true
             ;;
         --help)
-            echo "Usage: $0 [--dask-only] [--distributed-only] [--dask-cuda-only] [--dask-cudf-only] [--ucx-only]"
+            echo "Usage: $0 [--dask-only] [--distributed-only] [--dask-cuda-only] [--dask-cudf-only] [--dask-image-only] [--ucx-only]"
             exit 0
             ;;
         *)
@@ -95,6 +100,19 @@ if $run_dask_cuda; then
     fi
 
 fi
+
+# --- dask-image ---
+if $run_dask_image; then
+
+    echo "[testing dask-image]"
+    pytest -v packages/dask-image/
+
+    if [[ $? -ne 0 ]]; then
+        exit_code=1
+    fi
+
+fi
+
 
 # --- raft-dask ---
 if $run_raft_dask; then


### PR DESCRIPTION
https://github.com/dask/dask-image/pull/396 is fixing a minor issue upstream, so that we don't get warnings about unknown markers.

BTW, I currently see a failure locally:

```
_______________________________ test_cupy_imread _______________________________

tmp_path = PosixPath('/tmp/pytest-of-toaugspurger/pytest-241/test_cupy_imread0')

    @pytest.mark.cupy
    def test_cupy_imread(tmp_path):
        a = np.random.uniform(low=0.0, high=1.0, size=(1, 4, 3)).astype(np.float32)
    
        fn = str(tmp_path/"test.tiff")
        with tifffile.TiffWriter(fn) as fh:
            for i in range(len(a)):
>               fh.save(a[i])
E               AttributeError: 'TiffWriter' object has no attribute 'save'

packages/dask-image/tests/test_dask_image/test_imread/test_cupy_imread.py:17: AttributeError
=========================== short test summary info ============================
FAILED packages/dask-image/tests/test_dask_image/test_imread/test_cupy_imread.py::test_cupy_imread - AttributeError: 'TiffWriter' object has no attribute 'save'
=============== 1 failed, 141 passed, 2291 deselected in 11.51s ================
```

I haven't done any investigation to see if that's related.

cc @jakirkham.

Closes #38 