### PR TITLE
Fetch before checking out cudf

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -37,6 +37,7 @@ if [ ! -d "packages/cudf" ]; then
 fi
 
 pushd packages/cudf
+git fetch
 git checkout $cudf_commit
 popd
 


### PR DESCRIPTION
Previously this could fail when *re*running `./scripts/install.sh` since the commit we checkout might not be in the local checkout of cudf. All the other packages already `git fetch` before the `git checkout`.