### PR TITLE
Add configurable Dask branch to cron workflow

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -8,7 +8,12 @@ on:
     # https://github.com/rapidsai/workflows/blob/main/.github/workflows/nightly-pipeline-trigger.yaml is
     # currently set to 5:00 UTC and takes ~12 hours
     - cron: "15 06,18 * * *"
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      dask_branch:
+        type: string
+        description: Dask version, which will be checked out from the given branch. Default is main. Can be a tag like '2025.4.1'.
+        default: main
 
 jobs:
   setup:
@@ -23,12 +28,15 @@ jobs:
       - name: Get current branch
         id: branch
         run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> "$GITHUB_OUTPUT"
+      - name: Set Dask branch
+        id: dask-branch
+        run: echo "DASK_BRANCH=${{ inputs.dask_branch }}" >> "$GITHUB_OUTPUT"
 
   dask-tests:
     needs: setup
     # run the Dask and Distributed unit tests
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.04
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.06
     with:
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".
       matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -15,6 +15,9 @@ on:
         description: Dask version, which will be checked out from the given branch. Default is main. Can be a tag like '2025.4.1'.
         default: main
 
+env:
+  DASK_BRANCH: ${{ inputs.dask_branch }}
+
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -28,9 +31,6 @@ jobs:
       - name: Get current branch
         id: branch
         run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> "$GITHUB_OUTPUT"
-      - name: Set Dask branch
-        id: dask-branch
-        run: echo "DASK_BRANCH=${{ inputs.dask_branch }}" >> "$GITHUB_OUTPUT"
 
   dask-tests:
     needs: setup

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -17,6 +17,7 @@ on:
 
 env:
   DASK_BRANCH: ${{ inputs.dask_branch }}
+  UV_LINK_MODE: "copy"  # avoid warnings in CI
 
 jobs:
   setup:

--- a/README.md
+++ b/README.md
@@ -10,3 +10,10 @@ and dask-dependent tests from some downstream libraries.
 The primary goal here is to quickly identify breakages in tests defined in `dask/dask` and `dask/distributed`, so we'll use the latest `main` from each of those.
 
 When breakages occur, they'll generally be fixed either in Dask or in the the nightly versions of the downstream packages (rapids, cupy, numba, etc.). And so we install the nightly (rather than `latest`) version of the downstream packages.
+
+## Workflow Dispatch
+
+This repository uses [workflow dispatch](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onworkflow_dispatch) to enable running tests against
+a specific version of Dask.
+
+Navigate to the [cron workflow](https://github.com/rapidsai/dask-upstream-testing/actions/workflows/cron.yaml), select "Run workflow", and input a Dask version to test. This must be a branch name (like `main`) or a tag that is available in both Dask and Distributed repositorys (like `2025.4.1`). The default is `main`.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
 set -euo pipefail
 
+DASK_BRANCH=${DASK_BRANCH:-main}
+
 # RAPIDS_CUDA_VERSION is like 12.15.1
 # We want cu12
 RAPIDS_PY_CUDA_SUFFIX=$(echo "cu${RAPIDS_CUDA_VERSION:-12.15.1}" | cut -d '.' -f 1)
@@ -108,24 +110,24 @@ popd
 # depth needs to be sufficient to reach the last tag, so that the package
 # versions are set correctly
 if [ ! -d "packages/dask" ]; then
-    echo "Cloning dask@main"
-    git clone https://github.com/dask/dask --depth 100 packages/dask
+    echo "Cloning dask@${DASK_BRANCH}"
+    git clone https://github.com/dask/dask --depth 100 packages/dask --branch "${DASK_BRANCH}"
 fi
 
 if [ ! -d "packages/distributed" ]; then
-    echo "Cloning distributed@main"
-    git clone https://github.com/dask/distributed --depth 100 packages/distributed
+    echo "Cloning distributed@${DASK_BRANCH}"
+    git clone https://github.com/dask/distributed --depth 100 packages/distributed --branch "${DASK_BRANCH}"
 fi
 
 pushd packages/dask
 git fetch
-git checkout main
+git checkout "${DASK_BRANCH}"
 git pull
 popd
 
 pushd packages/distributed
 git fetch
-git checkout main
+git checkout "${DASK_BRANCH}"
 git pull
 popd
 


### PR DESCRIPTION
This adds a new input to the cron workflow that allows a user to specify a Dask branch or tag to test. The default is `main`, which is unchanged from today.

We'll use this to test against a specific version of Dask version in preparation for updating the pin in rapids-dask-dependency.

I don't think this is working right now. I believe that setting the `DASK_BRANCH` in the `setup` job won't automatically make it available to our `scripts/run.sh` which is run via the shared workflow.