### PR TITLE
Temporarily hardcode released dask version

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -9,14 +9,9 @@ on:
     # currently set to 5:00 UTC and takes ~12 hours
     - cron: "15 06,18 * * *"
   workflow_dispatch:
-    inputs:
-      dask_branch:
-        type: string
-        description: Dask version, which will be checked out from the given branch. Default is main. Can be a tag like '2025.4.1'.
-        default: main
+    inputs: {}
 
 env:
-  DASK_BRANCH: ${{ inputs.dask_branch }}
   UV_LINK_MODE: "copy"  # avoid warnings in CI
 
 jobs:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,7 +2,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
 set -euo pipefail
 
-DASK_BRANCH=${DASK_BRANCH:-main}
+# DASK_BRANCH=${DASK_BRANCH:-main}
+DASK_BRANCH=${DASK_BRANCH:-2025.4.1}
 
 # RAPIDS_CUDA_VERSION is like 12.15.1
 # We want cu12


### PR DESCRIPTION
In https://github.com/rapidsai/dask-upstream-testing/pull/45 we tried adding a workflow_dispatch parameter to set the Dask version. It didn't make it all the way to the test.sh script; the shared-workflow setup might not allow passing through variables.

So instead, we'll temporarily hardcode the dask version we test against. After the release we'll revert this change.