### PR TITLE
Upper bound on RAPIDS libraries

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -9,14 +9,9 @@ on:
     # currently set to 5:00 UTC and takes ~12 hours
     - cron: "15 06,18 * * *"
   workflow_dispatch:
-    inputs:
-      dask_branch:
-        type: string
-        description: Dask version, which will be checked out from the given branch. Default is main. Can be a tag like '2025.4.1'.
-        default: main
+    inputs: {}
 
 env:
-  DASK_BRANCH: ${{ inputs.dask_branch }}
   UV_LINK_MODE: "copy"  # avoid warnings in CI
 
 jobs:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,7 +2,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
 set -euo pipefail
 
-DASK_BRANCH=${DASK_BRANCH:-main}
+# DASK_BRANCH=${DASK_BRANCH:-main}
+DASK_BRANCH=${DASK_BRANCH:-2025.4.1}
 
 # RAPIDS_CUDA_VERSION is like 12.15.1
 # We want cu12

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,28 +9,30 @@ DASK_BRANCH=${DASK_BRANCH:-2025.4.1}
 # We want cu12
 RAPIDS_PY_CUDA_SUFFIX=$(echo "cu${RAPIDS_CUDA_VERSION:-12.15.1}" | cut -d '.' -f 1)
 
+# Controls which branch of rapids libraries give us the tests.
+export RAPIDS_BRANCH="branch-25.06"
+export RAPIDS_VERSION_RANGE=">=25.6.0a0,<25.8.0a0"
+
+
 uv pip install --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple \
   --overrides=requirements/overrides.txt \
   --prerelease allow \
   --upgrade \
   "dask-image[test] @ git+https://github.com/dask/dask-image.git@main" \
-  "cuml-${RAPIDS_PY_CUDA_SUFFIX}[test]" \
-  "cudf-${RAPIDS_PY_CUDA_SUFFIX}" \
-  "dask-cudf-${RAPIDS_PY_CUDA_SUFFIX}" \
-  "raft-dask-${RAPIDS_PY_CUDA_SUFFIX}" \
+  "cuml-${RAPIDS_PY_CUDA_SUFFIX}[test]${RAPIDS_VERSION_RANGE}" \
+  "cudf-${RAPIDS_PY_CUDA_SUFFIX}${RAPIDS_VERSION_RANGE}" \
+  "dask-cudf-${RAPIDS_PY_CUDA_SUFFIX}${RAPIDS_VERSION_RANGE}" \
+  "raft-dask-${RAPIDS_PY_CUDA_SUFFIX}${RAPIDS_VERSION_RANGE}" \
   "ucx-py-${RAPIDS_PY_CUDA_SUFFIX}" \
   "ucxx-${RAPIDS_PY_CUDA_SUFFIX}" \
   "scipy" \
-  "dask-cuda" \
+  "dask-cuda${RAPIDS_VERSION_RANGE}" \
   "pytest-timeout"
 
 # packages holds all the downstream and upstream dependencies.
 # we want to avoid directories with the same name as packages
 # in the working directory
 mkdir -p packages
-
-# Clone cudf repo for tests
-RAPIDS_BRANCH="branch-25.06"
 
 cudf_commit=$(./scripts/check-version.py cudf)
 


### PR DESCRIPTION
We're preparing to update the version of dask used in rapids-dask-dependency for the 2025.6.0 release.

This PR

- pins to dask==2025.4.1, the target version for rapids-dask-dependency
- Puts an upper bound of `<25.8.0a0` for rapids libraries, to ensure that we (temporarily) get the 25.6.0 alphas

This ensures that we're testing what we'll release against.

I think we'll want to relax both of these pins once rapids-dask-dependency is updated. Downstream projects' CIs will be testing against the released version dask==2025.4.1 by that point. And since the 2025.6.0 release will be using dask==2025.4.1, we don't need to worry about testing it against `main`.
