### PR TITLE
Use uv managed python for venv

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -9,7 +9,7 @@ if ! command -v uv > /dev/null; then
     source $HOME/.local/bin/env
 fi
 
-uv venv --allow-existing --python 3.12
+uv venv --allow-existing --python 3.12 --managed-python
 source .venv/bin/activate
 
 ./scripts/install.sh


### PR DESCRIPTION
This updates the `--python` we use in the container to fix the error seen [here](https://github.com/rapidsai/dask-upstream-testing/actions/runs/15003949797/job/42157759762#step:10:422).

That was picking up a python 3.12 from `/usr/bin/python3.12`. Something about that python was incompatible with what we're doing here. I haven't investigated much but it can be reproduced with


```
docker run -it --rm -v (pwd):/src --gpus all docker.io/rapidsai/citestwheel:cuda12.8.0-ubuntu24.04-py3.13
```

And in the container

```
curl -LsSf https://astral.sh/uv/install.sh | sh
. ~/.local/bin/env
uv venv --python 3.12   # gets 3.12.3 for some reason
. .venv/bin/activate

uv pip install --prerelease=allow --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple ucxx-cu12

python -c "import ucxx"
```

With `--managed-python` (3.12.3 or otherwise) the import succeeds.
