### PR TITLE
Target dask main

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,10 @@ This repository uses [workflow dispatch](https://docs.github.com/en/actions/writ
 a specific version of Dask.
 
 Navigate to the [cron workflow](https://github.com/rapidsai/dask-upstream-testing/actions/workflows/cron.yaml), select "Run workflow", and input a Dask version to test. This must be a branch name (like `main`) or a tag that is available in both Dask and Distributed repositorys (like `2025.4.1`). The default is `main`.
+
+## Version Upgrades
+
+We'd like to have a complete test run against a specific releaesd version of Dask prior to bumping the pin in [rapids-dask-dependency](https://github.com/rapidsai/rapids-dask-dependency). To test that
+
+1. Update `DASK_BRACH` in `install.sh` to select the tag for a specific version
+2. Update `overrides.txt` to pin to a specific version, rather than `main`

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,8 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
 set -euo pipefail
 
-# DASK_BRANCH=${DASK_BRANCH:-main}
-DASK_BRANCH=${DASK_BRANCH:-2025.4.1}
+DASK_BRANCH=${DASK_BRANCH:-main}
 
 # RAPIDS_CUDA_VERSION is like 12.15.1
 # We want cu12


### PR DESCRIPTION
Removes the 2025.4.1 "pin"

Closes #49 