### PR TITLE
Pin to python 3.12 in matrix filter

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -35,7 +35,10 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.06
     with:
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".
-      matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
+      # Pinned to 3.12 until all dependencies have wheels. Waiting for
+      # - https://pypi.org/project/hdbscan/
+      # matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
+      matrix_filter: map(select(.ARCH == "amd64")) | map(select(.PY_VER == "3.12")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
       build_type: nightly
       branch: ${{ needs.setup.outputs.branch }}
       date: ${{ needs.setup.outputs.date }}


### PR DESCRIPTION
This updates our matrix filter to select python 3.12.

Some dependencies (hdbscan ATM) don't have 3.13 wheels so we aren't able to bump to that yet.

I think this is also going to result in the cuda 11 version not being tested anymore (since it used python 3.10 IIRC). We were planning on dropping that build anyway.

Closes #56 