### PR TITLE
Update to RAPIDS 25.08

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -32,7 +32,7 @@ jobs:
     needs: setup
     # run the Dask and Distributed unit tests
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.06
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.08
     with:
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".
       # Pinned to 3.12 until all dependencies have wheels. Waiting for

--- a/README.md
+++ b/README.md
@@ -24,3 +24,12 @@ We'd like to have a complete test run against a specific releaesd version of Das
 
 1. Update `DASK_BRACH` in `install.sh` to select the tag for a specific version
 2. Update `overrides.txt` to pin to a specific version, rather than `main`
+
+## RAPIDS version update
+
+After code freeze for a specific RAPIDS version (e.g. 25.06) when it's anticipated that no Dask version update is imminent,
+update the targeted RAPIDS version by changing
+
+- `RAPIDS_BRANCH` in `install.sh`
+- `RAPID_VERSION_RANGE` in `install.sh`
+- The branch in the `jobs.dask-tests.uses` field of `cron.yaml`

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,8 +9,8 @@ DASK_BRANCH=${DASK_BRANCH:-main}
 RAPIDS_PY_CUDA_SUFFIX=$(echo "cu${RAPIDS_CUDA_VERSION:-12.15.1}" | cut -d '.' -f 1)
 
 # Controls which branch of rapids libraries give us the tests.
-export RAPIDS_BRANCH="branch-25.06"
-export RAPIDS_VERSION_RANGE=">=25.6.0a0,<25.8.0a0"
+export RAPIDS_BRANCH="branch-25.08"
+export RAPIDS_VERSION_RANGE=">=25.8.0a0,<25.10.0a0"
 
 
 uv pip install --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple \

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -9,11 +9,7 @@ if ! command -v uv > /dev/null; then
     source $HOME/.local/bin/env
 fi
 
-# Temporarily pin to uv 7.5's python-build-standalone.
-# Follow https://github.com/astral-sh/python-build-standalone/issues/619
-# and https://github.com/rapidsai/dask-upstream-testing/issues/56 for details.
-uvx uv@0.7.5 python install --reinstall 3.12
-uv venv --allow-existing --python 3.12 --managed-python --no-cache
+uv venv --allow-existing --python 3.12 --managed-python
 
 source .venv/bin/activate
 


### PR DESCRIPTION
Also reverts the changes for #56, since we should be getting a new version of libucxx with https://github.com/rapidsai/ucxx/pull/427.

Closes #59