### PR TITLE
Try setting UV_LINK_MODE=copy

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -11,9 +11,6 @@ on:
   workflow_dispatch:
     inputs: {}
 
-env:
-  UV_LINK_MODE: "copy"  # avoid warnings in CI
-
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -27,10 +24,12 @@ jobs:
       - name: Get current branch
         id: branch
         run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> "$GITHUB_OUTPUT"
+      - name: Set UV_LINK_MODE
+        id: link_mode
+        run: echo "LINK_MODE=copy" >> "$GITHUB_ENV"
 
   dask-tests:
     needs: setup
-    # run the Dask and Distributed unit tests
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.08
     with:


### PR DESCRIPTION
Our CI output currently contains messages like

    warning: Failed to hardlink files; falling back to full copy

e.g. https://github.com/rapidsai/dask-upstream-testing/actions/runs/15792973681/job/44521325602#step:11:435 This makes it hard to search for the string "failed". A previous attempt at a fix set this in the `env` mapping but that apparently didn't work. This tries setting it in `GITHUB_ENV` and hoping that it flows through to the test script.