### PR TITLE
Test dask==2025.7.0

### DIFF
--- a/requirements/overrides.txt
+++ b/requirements/overrides.txt
@@ -1,2 +1,2 @@
-dask[test] @ git+https://github.com/dask/dask.git@main
-distributed @ git+https://github.com/dask/distributed.git@main
+dask[test]==2025.7.0
+distributed==2025.7.0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
 set -euo pipefail
 
-DASK_BRANCH=${DASK_BRANCH:-main}
+DASK_BRANCH=${DASK_BRANCH:-"2025.7.0"}
 
 # RAPIDS_CUDA_VERSION is like 12.15.1
 # We want cu12


### PR DESCRIPTION
Pin to dask==2025.7.0, in preparation for bumping the target version across RAPIDS.