### PR TITLE
Run tests against dask main

### DIFF
--- a/requirements/overrides.txt
+++ b/requirements/overrides.txt
@@ -1,2 +1,2 @@
-dask[test]==2025.7.0
-distributed==2025.7.0
+dask[test] @ git+https://github.com/dask/dask.git@main
+distributed @ git+https://github.com/dask/distributed.git@main

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
 set -euo pipefail
 
-DASK_BRANCH=${DASK_BRANCH:-"2025.7.0"}
+DASK_BRANCH=${DASK_BRANCH:-main}
 
 # RAPIDS_CUDA_VERSION is like 12.15.1
 # We want cu12


### PR DESCRIPTION
This reverts commit 32b9d0ed7fa8206729d064bce5bc99287110eafb, which pinned us to dask==2025.7.0. That's out now, seemingly without issues, so we'll flip back to dask main.