### PR TITLE
Fix raft-dask test failures

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -151,7 +151,7 @@ fi
 if $run_raft_dask; then
 
     echo "[testing raft-dask]"
-    pytest -v --timeout=120 packages/raft/python/raft-dask/raft_dask/tests
+    pytest -v --import-mode=append --timeout=120 packages/raft/python/raft-dask/raft_dask/tests
 
     if [[ $? -ne 0 ]]; then
         exit_code=1


### PR DESCRIPTION
This fixes *some* of the test failures in raft-dask described in https://github.com/rapidsai/dask-upstream-testing/issues/73#issuecomment-3259147291, by using pytests `append` import mode.