### PR TITLE
Test Fixes

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -24,7 +24,7 @@ uv pip install --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-night
   "cugraph-${RAPIDS_PY_CUDA_SUFFIX}[test]${RAPIDS_VERSION_RANGE}" \
   "cuml-${RAPIDS_PY_CUDA_SUFFIX}[test,test-dask]${RAPIDS_VERSION_RANGE}" \
   "cudf-${RAPIDS_PY_CUDA_SUFFIX}${RAPIDS_VERSION_RANGE}" \
-  "cudf-polars-${RAPIDS_PY_CUDA_SUFFIX}${RAPIDS_VERSION_RANGE}" \
+  "cudf-polars-${RAPIDS_PY_CUDA_SUFFIX}[test]${RAPIDS_VERSION_RANGE}" \
   "dask-cudf-${RAPIDS_PY_CUDA_SUFFIX}${RAPIDS_VERSION_RANGE}" \
   "raft-dask-${RAPIDS_PY_CUDA_SUFFIX}${RAPIDS_VERSION_RANGE}" \
   "ucxx-${RAPIDS_PY_CUDA_SUFFIX}${UCXX_VERSION_RANGE}" \

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -75,7 +75,7 @@ exit_code=0;
 # --- cudf-polars ---
 if $run_cudf_polars; then
     echo "[testing cudf-polars]"
-    pytest -v --timeout 120 packages/cudf/python/cudf_polars/tests/experimental/ --executor streaming --cluster distributed
+    pytest -v --timeout 120 packages/cudf/python/cudf_polars/tests/experimental/legacy/ --executor streaming --cluster distributed
 
     if [[ $? -ne 0 ]]; then
         exit_code=1

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -185,7 +185,7 @@ if $run_distributed; then
     # https://github.com/rapidsai/dask-upstream-testing/issues/23
     # cuML fails to import tests when Dask / distributed is installed in editable mode.
     uv pip install --no-deps -e ./packages/distributed
-    pytest -v --timeout=120 -m gpu --runslow packages/distributed/distributed --deselect "distributed/comm/tests/test_ucx.py::test_registered" --deselect "distributed/comm/tests/test_ucx.py::test_ucx_specific" --deselect "distributed/distributed/tests/test_nanny.py::test_malloc_trim_threshold"
+    pytest -v --timeout=120 -m gpu --runslow packages/distributed/distributed --deselect "distributed/comm/tests/test_ucx.py::test_registered" --deselect "distributed/comm/tests/test_ucx.py::test_ucx_specific" --deselect "distributed/tests/test_nanny.py::test_malloc_trim_threshold"
 
     if [[ $? -ne 0 ]]; then
         exit_code=1


### PR DESCRIPTION
Fixes for the errors at https://github.com/rapidsai/dask-upstream-testing/actions/runs/23887719437

- Fix the deselect path for the malloc tests
- Only run legacy tests with `--cluster distributed` in cudf-polars (matches what we do in rapidsai/cudf)
- install cudf-polars test deps (fix structlog failure)