### PR TITLE
fix(ci): resolve all zizmor findings and add zizmor pre-commit checks

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -28,7 +28,7 @@ jobs:
         run: echo "LINK_MODE=copy" >> "$GITHUB_ENV"
   dask-tests:
     needs: setup
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
     with:
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -1,6 +1,5 @@
 # Based off https://github.com/rapidsai/cudf/blob/branch-25.04/.github/workflows/pandas-tests.yaml
 name: Test dask-upstream
-
 on:
   schedule:
     # 06:15 and 08:15 UTC daily.
@@ -10,7 +9,7 @@ on:
     - cron: "15 06,18 * * *"
   workflow_dispatch:
     inputs: {}
-
+permissions: {}
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -27,7 +26,6 @@ jobs:
       - name: Set UV_LINK_MODE
         id: link_mode
         run: echo "LINK_MODE=copy" >> "$GITHUB_ENV"
-
   dask-tests:
     needs: setup
     secrets: inherit
@@ -43,3 +41,9 @@ jobs:
       date: ${{ needs.setup.outputs.date }}
       sha: ${{ github.sha }}
       script: scripts/run.sh
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,5 +1,4 @@
 name: pr
-
 on:
   push:
     branches:
@@ -8,11 +7,10 @@ on:
     branches:
       - "main"
   workflow_dispatch: # allows you to trigger manually
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
+permissions: {}
 jobs:
   check-style:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -19,5 +19,6 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3.1.4
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,9 +17,9 @@ jobs:
   check-style:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - uses: actions/setup-python@v3
-    - uses: pre-commit/action@v3.0.1
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3.1.4
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,9 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # We require SHA-pinning for all workflows and actions _except_ for those from
+        # rapidsai/shared-workflows and rapidsai/shared-actions
+        "rapidsai/shared-workflows/*": any
+        "rapidsai/shared-actions/*": any
+        "*": hash-pin

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,3 +51,7 @@ repos:
       - id: shellcheck
         args: ["--severity=warning"]
         files: ^scripts/
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.24.1
+    hooks:
+      - id: zizmor


### PR DESCRIPTION

Similar to upstream changes in `shared-workflows`, this PR cleans up and annotates all of the workflows and adds the `zizmor` linter to make sure changes are checked.

Part of https://github.com/rapidsai/build-planning/issues/275