### PR TITLE
Add SECURITY.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+
+# Ops code owners
+/SECURITY.md             @rapidsai/ops-codeowners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,16 @@
 
 # Ops code owners
 /SECURITY.md             @rapidsai/ops-codeowners
+/.github/ @rapidsai/ci-codeowners
+/ci/ @rapidsai/ci-codeowners
+/conda/ @rapidsai/packaging-codeowners
+dependencies.yaml @rapidsai/packaging-codeowners
+/build.sh @rapidsai/packaging-codeowners
+pyproject.toml @rapidsai/packaging-codeowners
+/.pre-commit-config.yaml @rapidsai/packaging-codeowners
+/.devcontainer/ @rapidsai/packaging-codeowners
+cpp/ @rapidsai/cudf-cpp-codeowners
+python/ @rapidsai/cudf-python-codeowners
+CMakeLists.txt @rapidsai/cudf-cmake-codeowners
+**/cmake/ @rapidsai/cudf-cmake-codeowners
+*.cmake @rapidsai/cudf-cmake-codeowners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,16 +1,2 @@
-
 # Ops code owners
 /SECURITY.md             @rapidsai/ops-codeowners
-/.github/ @rapidsai/ci-codeowners
-/ci/ @rapidsai/ci-codeowners
-/conda/ @rapidsai/packaging-codeowners
-dependencies.yaml @rapidsai/packaging-codeowners
-/build.sh @rapidsai/packaging-codeowners
-pyproject.toml @rapidsai/packaging-codeowners
-/.pre-commit-config.yaml @rapidsai/packaging-codeowners
-/.devcontainer/ @rapidsai/packaging-codeowners
-cpp/ @rapidsai/cudf-cpp-codeowners
-python/ @rapidsai/cudf-python-codeowners
-CMakeLists.txt @rapidsai/cudf-cmake-codeowners
-**/cmake/ @rapidsai/cudf-cmake-codeowners
-*.cmake @rapidsai/cudf-cmake-codeowners

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,16 +35,6 @@ repos:
     rev: v1.4.3
     hooks:
       - id: verify-copyright
-        exclude: |
-          (?x)^(
-            cpp/include/cudf_test/cxxopts[.]hpp$|
-            cpp/src/io/parquet/ipc/Message_generated[.]h$|
-            cpp/src/io/parquet/ipc/Schema_generated[.]h$|
-            cpp/cmake/Modules/FindCUDAToolkit[.]cmake$
-          )
-      - id: verify-alpha-spec
-      - id: verify-codeowners
-        args: [--fix, --project-prefix=cudf]
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.10.0.1
     hooks:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security
+
+## Reporting Security Issues
+
+> [!WARNING]
+> Do not report security vulnerabilities through public GitHub issues!
+
+Instead, please submit a private vulnerability report, see below.
+
+## Reporting a Vulnerability
+
+1. **NVIDIA Vulnerability Disclosure Program (preferred)**
+   Submit through the NVIDIA Product Security Incident Response Team (PSIRT) web form (<https://www.nvidia.com/en-us/security/report-vulnerability/>)
+   This is the fastest path to triage and tracking.
+
+2. **Email NVIDIA PSIRT**
+   `psirt@nvidia.com` — encrypt sensitive reports with the
+   [NVIDIA PSIRT PGP key](https://www.nvidia.com/en-us/security/pgp-key).
+
+3. **GitHub Private Vulnerability Reporting**
+   Use the **Security and quality** tab on this repository → *Report a vulnerability*.
+
+## Report Details
+
+We prefer all communications to be in English.
+
+Reports should include the following:
+
+* reproducible example showing how the vulnerability can be exploited
+* statement about the impact (including affected versions)
+
+And we'd appreciate if they also include:
+
+* statement about whether you are interested in implementing the fix yourself
+
+## Disclosure Policy
+
+NVIDIA PSIRT will acknowledge receipt and coordinate triage, fix development, and coordinated disclosure.
+
+More on NVIDIA's response process: <https://www.nvidia.com/en-us/security/psirt-policies/>.

--- a/scripts/check-version.py
+++ b/scripts/check-version.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES.
 """
 Print the git commit a rapids package was built from.
 """
 
 import argparse
 import importlib
-import sys
 import importlib.resources
+import sys
 
 
 def parse_args(args=None):


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/281

* adds a `SECURITY.md` describing how to report security vulnerabilities

## Notes for Reviewers

### Why not just set this org-wide?

An org-wide default is set at https://github.com/rapidsai/.github/blob/main/SECURITY.md, but adding an actual file in each repo offers a few benefits:

* ensures security policy travels with the repo to forks, clones, mirrors, etc.
* allows per-repo governance over the security policy (via PR review, CODEOWNERS, etc.)