### PR TITLE
Attempt a workaround

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -87,7 +87,8 @@ fi
 if $run_cugraph; then
 
     echo "[testing cugraph]"
-    RAPIDS_DATASET_ROOT_DIR=packages/cugraph/datasets/ pytest -ra --timeout=120 packages/cugraph/python/cugraph/cugraph/ -k "_mg_" --import-mode=append
+    # Set DASK_DISTRIBUTED__CLIENT__SCHEDULER_INFO_INTERVAL to (maybe) avoid a race condition in distributed. Still investigating.
+    DASK_DISTRIBUTED__CLIENT__SCHEDULER_INFO_INTERVAL=100s RAPIDS_DATASET_ROOT_DIR=packages/cugraph/datasets/ pytest -ra --timeout=120 packages/cugraph/python/cugraph/cugraph/ -k "_mg_" --import-mode=append
 
     if [[ $? -ne 0 ]]; then
         exit_code=1


### PR DESCRIPTION
We're seeing flay zero division errors in cugraph (https://github.com/rapidsai/dask-upstream-testing/actions/runs/29312983270/job/87020694295) tests.

Maybe related to https://github.com/dask/distributed/pull/9308, but I'm not sure. Still trying to get a reliable reproducer, but this might help work around it for now.